### PR TITLE
Add nomodule polyfill pattern

### DIFF
--- a/src/js/modules/main/index.js
+++ b/src/js/modules/main/index.js
@@ -1,10 +1,4 @@
-import Promise from 'promise-polyfill';
-window.Promise = window.Promise ? window.Promise : Promise;
 import '@stormid/outliner';
 import { initStack } from '../..';
 const promisify = fn => fn.then ? fn() : Promise.resolve(fn());
-
-{
-    if (!Object.assign) import(/* webpackChunkName: "polyfills" */`../../polyfills`).then(() => Promise.all(initStack.map(promisify)));
-    else Promise.all(initStack.map(promisify));
-}
+Promise.all(initStack.map(promisify));

--- a/src/js/polyfills/index.js
+++ b/src/js/polyfills/index.js
@@ -1,3 +1,5 @@
 require('es6-object-assign').polyfill();
-require('picturefill');
+require('picturefill'); 
 // require('unfetch/polyfill');
+import Promise from 'promise-polyfill';
+window.Promise = window.Promise ? window.Promise : Promise;

--- a/src/templates/components/body/index.js
+++ b/src/templates/components/body/index.js
@@ -1,0 +1,5 @@
+import { h } from 'preact';
+
+const Body = ({children}) => <body>{children}</body>;
+
+export default Body;

--- a/src/templates/components/head/index.js
+++ b/src/templates/components/head/index.js
@@ -1,10 +1,19 @@
 import { h } from 'preact';
 
-const head = ({ title, meta, children }) => <head>
-    <meta charSet="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no" />
-    <link rel="shortcut icon" href={`/static/img/favicon.ico`} />
+const head = ({
+    charset = 'utf-8',
+    title,
+    meta,
+    viewport = 'width=device-width, initial-scale=1.0, shrink-to-fit=no',
+    favicon = `/static/img/favicon.ico`,
+    css,
+    children
+}) => <head>
+    <meta charset={charset} />
+    <meta name="viewport" content={viewport} />
+    <link rel="shortcut icon" href={favicon} />
     <title>{title}</title>
+    {css && <link rel="stylesheet" href={`/${css}`} />}
     {children}
     {meta && meta.map(item => {
         if (item.name) return <meta name={item.name} content={item.content} />;

--- a/src/templates/components/html/index.js
+++ b/src/templates/components/html/index.js
@@ -1,0 +1,21 @@
+import { h } from 'preact';
+import Head from '../head';
+import Body from '../body';
+
+const Html = ({
+    lang = 'en',
+    title,
+    meta,
+    css,
+    basePath,
+    children
+}) => <html lang={lang}>
+    <Head title={title} meta={meta} css={css} />
+    <Body>
+        {children}
+        <script nomodule src={`${basePath}/polyfills.js`}></script>
+        <script src={`${basePath}/index.js`} />
+    </Body>
+</html>;
+
+export default Html;

--- a/src/templates/layouts/default.js
+++ b/src/templates/layouts/default.js
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { Fragment, h } from 'preact';
 import Skip from '@components/skip';
 import Header from '@components/header';
 // import ExampleNavigation from '@components/example-navigation';
@@ -6,7 +6,7 @@ import Header from '@components/header';
 import Main from '@components/main';
 import Footer from '@components/footer';
 
-const Default = ({ children, section }) => <body>
+const Default = ({ children, section }) => <Fragment>
     <Header>
         <Skip />
         {/* <ExampleNavigation ariaLabel={'Main navigation'}>
@@ -17,6 +17,6 @@ const Default = ({ children, section }) => <body>
         { children }
     </Main>
     <Footer />
-</body>;
+</Fragment>;
 
 export default Default;

--- a/tools/webpack/config/base/index.js
+++ b/tools/webpack/config/base/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     main: require('./main'),
-    javascript: require('./javascript')
+    javascript: require('./javascript'),
+    polyfills: require('./polyfills')
 };

--- a/tools/webpack/config/base/polyfills.js
+++ b/tools/webpack/config/base/polyfills.js
@@ -1,22 +1,15 @@
 const path = require('path');
-const webpack = require('webpack');
 const paths = require(path.join(process.cwd(), `./paths.config`));
 
 module.exports = {
     entry: {
-        index: path.join(process.cwd(), `${paths.src.js}/modules/main/index.js`),
-        head: path.join(process.cwd(), `${paths.src.js}/head.js`)
+        polyfills: path.join(process.cwd(), `${paths.src.js}/polyfills/index.js`)
     },
     target: 'web',
     stats: {
         modules: false,
         entrypoints: false
     },
-    plugins: [
-        new webpack.optimize.MinChunkSizePlugin({
-            minChunkSize: 30000
-        })
-    ],
     module: {
         rules: [
             {

--- a/tools/webpack/config/build/index.js
+++ b/tools/webpack/config/build/index.js
@@ -72,5 +72,16 @@ module.exports = [
         //         to: path.resolve(__dirname, `../../../../build/static/js/async`)
         //     }])
         ]
+    }),
+    merge(base.polyfills, {
+        output: {
+            filename: '[name].js',
+            publicPath: paths.webpackPublicPath,
+            path: path.join(process.cwd(), paths.output, paths.dest.js)
+        },
+        mode: 'production',
+        performance: {
+            hints: 'warning'
+        },
     })
 ];

--- a/tools/webpack/config/dev/index.js
+++ b/tools/webpack/config/dev/index.js
@@ -62,17 +62,15 @@ module.exports = [
             path: path.join(process.cwd(), paths.output)
         },
         mode: 'development',
-        devtool: 'cheap-module-eval-source-map',
-        // optimization: {
-        //     splitChunks: {
-        //         cacheGroups: {
-        //             vendor: {
-        //                 test: /[\\/]node_modules[\\/]/,
-        //                 name: 'vendors',
-        //                 chunks: 'all'
-        //             }
-        //         }
-        //     }
-        // }
+        devtool: 'cheap-module-eval-source-map'
+    }),
+    merge(base.polyfills, {
+        output: {
+            filename: '[name].js',
+            publicPath: '/',
+            path: path.join(process.cwd(), paths.output)
+        },
+        mode: 'development',
+        devtool: 'cheap-module-eval-source-map'
     })
 ];

--- a/tools/webpack/config/integration/index.js
+++ b/tools/webpack/config/integration/index.js
@@ -56,5 +56,13 @@ module.exports = [
         plugins: [
             new CleanWebpackPlugin()
         ]
+    }),
+    merge(base.polyfills, {
+        output: {
+            filename: '[name].js',
+            publicPath: paths.webpackPublicPath,
+            path: path.join(process.cwd(), paths.integrationOutput, paths.dest.js)
+        },
+        mode: 'production'
     })
 ];

--- a/tools/webpack/plugins/default-html.js
+++ b/tools/webpack/plugins/default-html.js
@@ -1,13 +1,14 @@
 const h = require('preact').h;
-const Head = require('../../../src/templates/components/head').default;
+const Html = require('../../../src/templates/components/html').default;
 const paths = require('../../../paths.config');
 
-const html = ({ htmlBody, css, title, meta }) => <html lang="en">
-    <Head title={title} meta={meta}>
-        {css && <link rel="stylesheet" href={`/${css}`} />}
-        <script src={`${process.env.NODE_ENV === 'production' ? `/${paths.dest.js}` : ''}/index.js`} async />
-    </Head>
+const html = ({ htmlBody, css, title, meta }) => <Html
+    css={css}
+    title={title}
+    meta={meta}
+    basePath={`${process.env.NODE_ENV === 'production' ? `/${paths.dest.js}` : ''}`} 
+>
     {htmlBody}
-</html>;
+</Html>;
 
 module.exports = html;


### PR DESCRIPTION
Fixes #59 

This PR changes how we deal with polyfilling legacy browsers thereby reducing the size of index.js for modern browsers. 

Currently we check for feature support/cutting the mustard - the existence of Object.assign by default - and use a dynamic import to import the polyfills if required. Unfortunately dynamic imports require Promises, so we need to polyfill Promises for this method to work, which means that every browser gets the Promise polyfill whether it needs it or not. This has always pained me.

This PR
- removes dynamic import of polyfills
- adds a script tag to the document body for polyfills
- uses support of the nomodule attribute of the script tag to determine whether a browser loads the script and gets the polyfills or not. https://caniuse.com/?search=nomodule compares favourable with our browser support list.
- some restructuring of the webpack entry points and creates an html and body components to make it easier to customise them (previously they were hidden in the webpack config)
