### PR TITLE
Add Heading component

### DIFF
--- a/src/templates/components/heading/index.js
+++ b/src/templates/components/heading/index.js
@@ -1,0 +1,15 @@
+import { h, toChildArray } from 'preact';
+
+const Heading = ({ level = 1, children, className }) => {
+    const Tag = `h${level}`;
+    return  <Tag class={className}>
+            {
+                toChildArray(children).length > 1
+                    ? <span role="text">{children}</span>
+                    : children
+                
+            }
+        </Tag>;
+};
+
+export default Heading;


### PR DESCRIPTION
Adds a Heading component that accepts a level and className props.

The component checks if their are child element nodes and adds a wrapper span[role="text"] to improve screen reader announcements.

Full description in #98 