### PR TITLE
#107 Split Figure from Image into own component.

### DIFF
--- a/docs/making-websites/components/figure.md
+++ b/docs/making-websites/components/figure.md
@@ -1,0 +1,59 @@
+## Figure
+
+The Figure component is a wrapper around the HTML figure element. The figure element is self-contained (like a complete sentence) and is typically referenced as a single unit from the main flow of the document. Most often used to annotate illustrations, diagrams, photos, poems, and code listings.
+
+## Props
+
+| Prop             | Description                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| children         | child elements, [any flow content is permitted](https://html.spec.whatwg.org/multipage/dom.html#flow-content-2) |
+| className        | figure element className                                                                                        |
+| caption          | figcaption content                                                                                              |
+| captionClassName | figcaption element className                                                                                    |
+
+## Example
+
+Using the Figure and Image components together (either can be used on their own).
+
+First import the Figure and Image components
+
+```
+import Image from '@components/image';
+import Figure from '@components/figure';
+```
+
+Then use them
+
+```
+<Figure
+	caption={'Stock photography site portayal of healthy living'}
+	className={'figure'}
+>
+	<Image
+	  alt="Woman laughing alone with a salad in her hand"
+	  className="picture"
+	  sources={[
+		{ src: '/static/img/portrait.jpg', media: '(min-width: 768px)' },
+		{ src: '/static/img/portrait-small.jpg', media: '(max-width: 767px)' },
+	  ]}
+	  src={'/static/img/portrait-low-res.jpg'}
+	  decoding="auto"
+	  loading="eager"
+	  height="300"
+	  width="800"
+	/>
+</Figure>
+```
+
+Renders
+
+```
+<figure class="figure">
+	<picture class="picture">
+		<source srcset="/static/img/image.jpg" media="(min-width: 768px)" />
+		<source srcset="/static/img/image-small.jpg" media="(max-width: 767px)" />
+		<img src="/static/img/image-low-res.jpg" alt="Woman laughing alone with a salad in her hand" decoding="auto" loading="eager" height="300" width="800">
+	</picture>
+	<figcaption>Stock photography site portayal of healthy living</figcaption>
+</figure>
+```

--- a/src/templates/components/figure/index.js
+++ b/src/templates/components/figure/index.js
@@ -1,0 +1,25 @@
+import { h } from 'preact';
+
+/**
+ * Wrapper for flow content (eg Image component), usually where a caption is required
+ * Any flow content is permitted: https://html.spec.whatwg.org/multipage/dom.html#flow-content-2
+ * @param {Object} children - Child elements
+ * @param {string} caption - Text to display within figcaption
+ * @param {string} className - Class name for the <figure>
+ * @param {string} captionClassName - Class name  for the <caption>
+ */
+const Figure = ({
+    children,
+    className=null,
+    captionClassName=null,
+    caption
+}) => <figure class={className}>
+    { children }
+    { caption &&
+        <figcaption class={captionClassName}>
+            {caption}
+        </figcaption>
+    }
+</figure>;
+
+export default Figure;

--- a/src/templates/components/image/index.js
+++ b/src/templates/components/image/index.js
@@ -13,7 +13,7 @@ import { h } from 'preact';
  * @param {string} width=null - Image width attribute
  **/
 
-const Image=({
+const Image = ({
     alt,
     className,
     decoding = 'async',
@@ -37,24 +37,3 @@ const Image=({
 </picture>;
 
 export default Image;
-
-/**
- * Wrapper for ImageBlock component, usually where a caption is required
- * @param {Object} children - an ImageBlock 
- * @param {string} caption - Text to display with image
- * @param {string} className - Class name for the <figure>
- * @param {string} captionClassName - Class name  for the <caption>
- */
-export const Figure = ({
-    children,
-    className,
-    captionClassName,
-    caption
-}) => <figure class={className}>
-    { children }
-    { caption &&
-        <figcaption class={captionClassName}>
-            {caption}
-        </figcaption>
-    }
-</figure>;


### PR DESCRIPTION
Per issue 107, pulled the Figure from the Image component to decouple implied usage.
Leaving Figure utility component in Scaffold, rather than removing completely.