### PR TITLE
Added fetchPriority to <Image>

### DIFF
--- a/docs/making-websites/components/image.md
+++ b/docs/making-websites/components/image.md
@@ -9,7 +9,7 @@ The Image component is an abstraction over the HTML Picture element to simplify 
 | alt          | img alt text                                                                                                                                                                                     |
 | className    | picture element className                                                                                                                                                                        |
 | decoding     | img element decoding attribute, Enum: 'async'/'sync'/'auto', default 'async'                                                                                                                     |
-| fetchPriority       | img element fetchpriority attribute, Enum: 'high'/'low'/'auto', default 'auto'                                                                                                                      |
+| fetchPriority       | img element fetchpriority attribute, Enum: 'high'/'low'/'auto', default null                                                                                                                      |
 | height       | img element height attribute, Number, default null                                                                                                                     |
 | imgClassName | img element className                                                                                                                                                                            |
 | loading      | img element loading attribute, Enum: 'lazy'/'eager', default 'lazy'                                                                                                                              |

--- a/docs/making-websites/components/image.md
+++ b/docs/making-websites/components/image.md
@@ -9,6 +9,7 @@ The Image component is an abstraction over the HTML Picture element to simplify 
 | alt          | img alt text                                                                                                                                                                                     |
 | className    | picture element className                                                                                                                                                                        |
 | decoding     | img element decoding attribute, Enum: 'async'/'sync'/'auto', default 'async'                                                                                                                     |
+| fetchPriority       | img element fetchpriority attribute, Enum: 'high'/'low'/'auto', default 'auto'                                                                                                                      |
 | height       | img element height attribute, Number, default null                                                                                                                     |
 | imgClassName | img element className                                                                                                                                                                            |
 | loading      | img element loading attribute, Enum: 'lazy'/'eager', default 'lazy'                                                                                                                              |
@@ -35,6 +36,7 @@ Then use it
 		{ src: '/static/img/image-small.jpg', media: '(max-width: 767px)' },
 	  ]}
 	  src={'/static/img/image-low-res.jpg'}
+	  fetchPriority="high"
 	  decoding="auto"
 	  loading="eager"
 	  height="300"
@@ -48,66 +50,7 @@ Renders
 <picture class="picture">
 	<source srcset="/static/img/image.jpg" media="(min-width: 768px)" />
 	<source srcset="/static/img/image-small.jpg" media="(max-width: 767px)" />
-	<img src="/static/img/image-low-res.jpg" alt="Woman laughing alone with a salad in her hand" decoding="auto" loading="eager" height="300" width="800">
+	<img src="/static/img/image-low-res.jpg" alt="Woman laughing alone with a salad in her hand" decoding="auto" fetchpriority="high" loading="eager" height="300" width="800">
 </picture>
 
-```
-
-## Figure
-
-The Figure component is a wrapper around the figure element. The figure element is self-contained (like a complete sentence) and is typically referenced as a single unit from the main flow of the document. Most often sed to annotate illustrations, diagrams, photos, poems, and code listings.
-
-## Props
-
-| Prop             | Description                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| children         | child elements, [any flow content is permitted](https://html.spec.whatwg.org/multipage/dom.html#flow-content-2) |
-| className        | figure element className                                                                                        |
-| caption          | figcaption content                                                                                              |
-| captionClassName | figcaption element className                                                                                    |
-
-## Example
-
-Using the Figure and Image components together (either can be used on their own).
-
-First import the Figure component
-
-```
-import Image, { Figure } from '@components/image';
-```
-
-Then use it
-
-```
-<Figure
-	caption={'Stock photography site portayal of healthy living'}
-	className={'figure'}
->
-	<Image
-	  alt="Woman laughing alone with a salad in her hand"
-	  className="picture"
-	  sources={[
-		{ src: '/static/img/portrait.jpg', media: '(min-width: 768px)' },
-		{ src: '/static/img/portrait-small.jpg', media: '(max-width: 767px)' },
-	  ]}
-	  src={'/static/img/portrait-low-res.jpg'}
-	  decoding="auto"
-	  loading="eager"
-	  height="300"
-	  width="800"
-	/>
-</Figure>
-```
-
-Renders
-
-```
-<figure class="figure">
-	<picture class="picture">
-		<source srcset="/static/img/image.jpg" media="(min-width: 768px)" />
-		<source srcset="/static/img/image-small.jpg" media="(max-width: 767px)" />
-		<img src="/static/img/image-low-res.jpg" alt="Woman laughing alone with a salad in her hand" decoding="auto" loading="eager" height="300" width="800">
-	</picture>
-	<figcaption>Stock photography site portayal of healthy living</figcaption>
-</figure>
 ```

--- a/src/templates/components/image/index.js
+++ b/src/templates/components/image/index.js
@@ -5,6 +5,7 @@ import { h } from 'preact';
  * @param {string} alt - Image alt tag
  * @param {string} className - Class name
  * @param {string} decoding='async' - 'async', 'sync', 'auto'
+ * @param {string} fetchpriority='auto' - 'high', 'low', 'auto'
  * @param {string} height=null - Image height attribute
  * @param {string} imgClassName - img element Class name
  * @param {string} loading='lazy' - 'lazy', 'eager'
@@ -17,8 +18,9 @@ const Image = ({
     alt,
     className,
     decoding = 'async',
-    imgClassName,
+    fetchPriority = 'auto',
     height = null,
+    imgClassName,
     loading = 'lazy',
     src,
     sources,
@@ -29,6 +31,7 @@ const Image = ({
         alt={alt}
         class={imgClassName}
         decoding={decoding}
+        fetchpriority={fetchPriority}
         height={height}
         loading={loading}
         src={`${src}`}

--- a/src/templates/components/image/index.js
+++ b/src/templates/components/image/index.js
@@ -18,7 +18,7 @@ const Image = ({
     alt,
     className,
     decoding = 'async',
-    fetchPriority = 'auto',
+    fetchPriority = null,
     height = null,
     imgClassName,
     loading = 'lazy',


### PR DESCRIPTION
Add support for the fetchpriority attribute, per [issue 120](https://github.com/stormid/scaffold/issues/120).
Following official guidance, the default is set to "auto" allowing the browser to choose the best loading strategy.