### PR TITLE
Make basepath absolute

### DIFF
--- a/tools/webpack/entry/template.js
+++ b/tools/webpack/entry/template.js
@@ -6,7 +6,7 @@ const html = ({ htmlBody, css, title, meta }) => <Html
     css={css}
     title={title}
     meta={meta}
-    basePath={`${process.env.NODE_ENV === 'production' ? `${paths.dest.js}` : ''}`}
+    basePath={`/${process.env.NODE_ENV === 'production' ? `${paths.dest.js}` : ''}`}
 >
     {htmlBody}
 </Html>;


### PR DESCRIPTION
I made this commit a few months back to fix a similar issue:

https://github.com/stormid/scaffold/commit/a27f2c8c9071dc93c46211ab02f7de50b1180221

I think this needs to be updated now that the default in the paths file isn't an absolute link.. this seemed to work in both dev and build for me.. does this look OK?